### PR TITLE
Add support for multiple SSH deploy keys.

### DIFF
--- a/bk_ssm_secrets/helpers.py
+++ b/bk_ssm_secrets/helpers.py
@@ -30,18 +30,17 @@ def extract_ssh_agent_envars(agent_output):
     SSH_AUTH_SOCK=/tmp/ssh-KgoPdeGP2LPZ/agent.24789; export SSH_AUTH_SOCK;
     SSH_AGENT_PID=24790; export SSH_AGENT_PID;
     echo Agent pid 24790;
+
+    return a dict that looks like:
+
+    {
+        'SSH_AUTH_SOCK': '/tmp/ssh-KgoPdeGP2LPZ/agent.24789',
+        'SSH_AGENT_PID': '24790'
+    }
     '''
-    agent_env_vars = {}
-    logging.debug(f"agent_output: {agent_output}")
-    output = agent_output.replace('\n', '').split(';')
+    pairs = [line.split(";")[0] for line in agent_output.decode().splitlines()[:2]]
+    return {pair.split("=")[0]: pair.split("=")[1] for pair in pairs}
 
-    for line in output:
-        key_val_pair = line.split('=')
-        if len(key_val_pair) == 2:
-            agent_env_vars[key_val_pair[0]] = key_val_pair[1]
-            os.environ[key_val_pair[0]]  = key_val_pair[1]
-
-    return agent_env_vars
 
 def dump_env_secrets(env_before):
     # Get difference in sets

--- a/hooks/environment
+++ b/hooks/environment
@@ -6,11 +6,35 @@ _source="${BASH_SOURCE[0]}"
 _source_dir="$( cd "$( dirname "${_source}" )" && cd .. && pwd )"
 pipe="/tmp/$$.stderr"
 
+get-ssm () {
+  aws ssm get-parameter --name "$1" --query "Parameter.Value" --with-decryption --output text
+}
+
+get-role () {
+  # Get the IAM role to determine the path we should use
+  detected_role="$(curl -s http://169.254.169.254/latest/meta-data/iam/info | jq '.InstanceProfileArn' | sed -E 's/.*agents-(\w+)-.*/\1/')"
+  case "${detected_role:-}" in
+    cde|infra)
+      echo "$detected_role"
+      ;;
+    *)
+      echo "default"
+      ;;
+  esac
+}
+
 # shellcheck disable=SC1090
 [ -f "${_source_dir}/custom-defaults" ] && source "${_source_dir}/custom-defaults"
 
 [ -z "${BUILDKITE_PLUGIN_AWS_PARAMSTORE_SECRETS_DEFAULT_KEY:-}" ] && BUILDKITE_PLUGIN_AWS_PARAMSTORE_SECRETS_DEFAULT_KEY="global"
 [ -z "${BUILDKITE_PLUGIN_AWS_PARAMSTORE_SECRETS_PATH:-}" ] && BUILDKITE_PLUGIN_AWS_PARAMSTORE_SECRETS_PATH="/vendors/buildkite/secrets"
+
+if [ "${BUILDKITE_PLUGIN_AWS_PARAMSTORE_SECRETS_MODE}" = "repo" ]
+then
+  echo "Adding Buildkite plugins project access key to an SSH agent"
+  eval $(/usr/bin/ssh-agent | sed "/^echo/d")
+  get-ssm "/vendors/buildkite/$(get-role)/global/ssh/bkpl-project" | ssh-add - 2>/dev/null
+fi
 
 # Prepare a fifo that can get stderr.
 rm -f "$pipe" && mkfifo "$pipe" && exec 3<> $pipe

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export SSH_AUTH_SOCK="${ORIG_SSH_AUTH_SOCK}"
+export SSH_AGENT_PID="${ORIG_SSH_AGENT_PID}"
+
+unset ORIG_SSH_AUTH_SOCK
+unset ORIG_SSH_AGENT_PID

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export ORIG_SSH_AUTH_SOCK="${SSH_AUTH_SOCK}"
+export ORIG_SSH_AGENT_PID="${SSH_AGENT_PID}"
+
+try-ssh () {
+  success="true"
+  SSH_AUTH_SOCK=$1 SSH_AGENT_PID=$2 git ls-remote -q "$BUILDKITE_REPO" 2>/dev/null >/dev/null || success="false"
+  echo "$success"
+}
+
+repo_works=$(try-ssh "${BK_SSM_SSH_AGENT_REPO_AUTH_SOCK}" "${BK_SSM_SSH_AGENT_REPO_AGENT_PID}")
+if [ "$repo_works" = "true" ]
+then
+  export SSH_AUTH_SOCK="${BK_SSM_SSH_AGENT_REPO_AUTH_SOCK}"
+  export SSH_AGENT_PID="${BK_SSM_SSH_AGENT_REPO_AGENT_PID}"
+else
+  project_works=$(try-ssh "${BK_SSM_SSH_AGENT_PROJECT_AUTH_SOCK}" "${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID}")
+  if [ "$project_works" = "true" ]
+  then
+    export SSH_AUTH_SOCK="${BK_SSM_SSH_AGENT_PROJECT_AUTH_SOCK}"
+    export SSH_AGENT_PID="${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID}"
+  else
+    >&2 echo "No ssh agent works. Using the default one"
+  fi
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -4,3 +4,21 @@ if [[ -n "${SSH_AGENT_PID:-}" ]] && ps -p "$SSH_AGENT_PID" &>/dev/null; then
   echo "~~~ Stopping ssh-agent ${SSH_AGENT_PID}"
   ssh-agent -k
 fi
+
+if [[ -n "${BK_SSM_SSH_AGENT_REPO_AGENT_PID:-}" ]] && ps -p  "${BK_SSM_SSH_AGENT_REPO_AGENT_PID}" &>/dev/null
+then
+  echo "~~~ Stopping ssh-agent ${BK_SSM_SSH_AGENT_REPO_AGENT_PID}"
+  kill "${BK_SSM_SSH_AGENT_REPO_AGENT_PID}"
+fi
+
+unset BK_SSM_SSH_AGENT_REPO_AGENT_PID
+unset BK_SSM_SSH_AGENT_REPO_AUTH_SOCK
+
+if [[ -n "${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID:-}" ]] && ps -p  "${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID}" &>/dev/null
+then
+  echo "~~~ Stopping ssh-agent ${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID}"
+  kill "${BK_SSM_SSH_AGENT_PROJECT_AGENT_PID}"
+fi
+
+unset BK_SSM_SSH_AGENT_PROJECT_AGENT_PID
+unset BK_SSM_SSH_AGENT_PROJECT_AUTH_SOCK


### PR DESCRIPTION
We used to add all deploy keys into the same SSH agent, this is not
going to work because git will always use the first deploy key.

So instead, we create at most three ssh-agents, one for buildkite
plugins, one for repo and one for project.

Signed-off-by: Kai Xia <kaix+github@fastmail.com>