### PR TITLE
Search for "bk-ssm-secrets" in PATH

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -18,7 +18,7 @@ then
   get-ssm "${AWS_PARAMSTORE_SECRETS_GLOBAL_SSH}" | ssh-add - 2>/dev/null
 fi
 
-exports=$(/usr/local/bin/bk-ssm-secrets)
+exports=$(bk-ssm-secrets)
 
 set -o allexport
 # shellcheck disable=SC1090


### PR DESCRIPTION
We've recently experienced an issue, that after an upgrade of python setuptools to version 49, the default `--prefix` has changed on our agent instances. `bk-ssm-secrets` was installed into `/usr/bin` instead of `/usr/local/bin`. Both `/usr/loca/bin` and `/usr/bin` are in $PATH, so it make sense to avoid hardcoding the path to `bk-ssm-secrets` script in `hooks/environment`.