### PR TITLE
Allow using ssh deploy keys for pipeline slug

### DIFF
--- a/bk_ssm_secrets/bksecrets.py
+++ b/bk_ssm_secrets/bksecrets.py
@@ -29,11 +29,6 @@ class BkSecrets(object):
             os.environ[key_name] = value
 
     def parse_ssh(self):
-        if self.slug == os.environ["BUILDKITE_PIPELINE_SLUG"]:
-            if 'ssh' in self.store:
-                logging.warning("Ignore pipeline level ssh keys.")
-            return
-
         if self.slug == config.DEFAULT_SLUG:
             if 'ssh' in self.store:
                 logging.warning("Ignore default ssh keys.")


### PR DESCRIPTION
Currently, the plugin ignores ssh keys defined for pipeline `$PREFIX/$BUILDKITE_PIPELINE_SLUG/ssh/key` and forces us to use 1 ssh key per repo (or a global ssh key). Github supports multiple deploy keys for a single GitHub repository. This allows us to add one readonly key used for CI pipeline and one read/write key used for other pipelines for the same repository that require push access to the repo from CI (e.g. to create automated PRs).

Removing these 5 lines seem to fix the issue and ssh keys defined for `$BUILDKITE_PIPELINE_SLUG`  are not ignored anymore